### PR TITLE
hacky approach to support row group filtering on columns of repeated type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: java
-before_install:
-  - bash dev/travis-before_install.sh
-
+dist: trusty
+branches:
+  only:
+    - master
 jdk:
   - openjdk8
-
 env:
   - HADOOP_PROFILE=default TEST_CODECS=gzip,snappy
-
-install: mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)
-script: mvn verify --batch-mode javadoc:javadoc -P $HADOOP_PROFILE
+sudo: required
+before_install:
+  - bash dev/travis-before_install.sh
+install:
+  mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)
+jobs:
+  include:
+    - stage: test
+      name: "Check"
+      script: mvn verify --batch-mode javadoc:javadoc -P $HADOOP_PROFILE
+    - stage: publish
+      if: branch = master AND type = push OR commit_message = PUBLISH
+      name: "Publish"
+      script: mvn deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ jobs:
     - stage: publish
       if: branch = master AND type = push OR commit_message = PUBLISH
       name: "Publish"
-      script: mvn deploy
+      script: mvn deploy -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jdk:
   - openjdk8
 
 env:
-  - HADOOP_PROFILE=default TEST_CODECS=uncompressed,brotli
   - HADOOP_PROFILE=default TEST_CODECS=gzip,snappy
 
 install: mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
 
 jdk:
   - openjdk8
-  - openjdk11
 
 env:
   - HADOOP_PROFILE=default TEST_CODECS=uncompressed,brotli

--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -29,14 +29,13 @@ EOF
 fi
 
 release_version="$1"
-release_tag="optimizely-parquet-$release_version"
+release_tag="apache-parquet-$release_version"
 rc_tag="$release_tag-rc$2"
 new_development_version="$3-SNAPSHOT"
 
-git tag -am "Release Optimizely Parquet $release_version" "$release_tag" "$rc_tag"
-mvn --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version" -X
-mvn -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version" -X
+git tag -am "Release Apache Parquet $release_version" "$release_tag" "$rc_tag"
+mvn --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version"
+mvn -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version"
 git commit -am 'Prepare for next development iteration'
 
-echo
 echo "Verify the release tag and the current development version then push the changes by running: git push --follow-tags"

--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -29,13 +29,13 @@ EOF
 fi
 
 release_version="$1"
-release_tag="apache-parquet-$release_version"
+release_tag="optimizely-parquet-$release_version"
 rc_tag="$release_tag-rc$2"
 new_development_version="$3-SNAPSHOT"
 
-git tag -am "Release Apache Parquet $release_version" "$release_tag" "$rc_tag"
-mvn --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version"
-mvn -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version"
+git tag -am "Release Optimizely Parquet $release_version" "$release_tag" "$rc_tag"
+mvn --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version" -X
+mvn -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version" -X
 git commit -am 'Prepare for next development iteration'
 
 echo

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -38,7 +38,7 @@ new_development_version="$release_version-SNAPSHOT"
 
 tag="apache-parquet-$release_version-rc$2"
 
-mvn release:clean -Dmaven.test.skip=true -X
-mvn release:prepare -Dmaven.test.skip=true -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version" -X
+mvn release:clean
+mvn release:prepare -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
 
 echo "Finish staging binary artifacts by running: mvn release:perform"

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -38,7 +38,7 @@ new_development_version="$release_version-SNAPSHOT"
 
 tag="apache-parquet-$release_version-rc$2"
 
-mvn release:clean
-mvn release:prepare -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
+mvn release:clean -Dmaven.test.skip=true -X
+mvn release:prepare -Dmaven.test.skip=true -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version" -X
 
 echo "Finish staging binary artifacts by running: mvn release:perform"

--- a/dev/travis-before_install.sh
+++ b/dev/travis-before_install.sh
@@ -20,7 +20,7 @@
 # This script gets invoked by .travis.yml in the before_install step
 ################################################################################
 
-export THIFT_VERSION=0.12.0
+export THRIFT_VERSION=0.13.0
 
 set -e
 date
@@ -30,8 +30,8 @@ sudo apt-get install -qq --no-install-recommends build-essential pv autoconf aut
    libevent-dev automake libtool flex bison pkg-config g++ libssl-dev xmlstarlet
 date
 pwd
-wget -qO- https://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz | tar zxf -
-cd thrift-${THIFT_VERSION}
+wget -qO- https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz | tar zxf -
+cd thrift-${THRIFT_VERSION}
 chmod +x ./configure
 ./configure --disable-libs
 sudo make install

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/SchemaCompatibilityValidator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/SchemaCompatibilityValidator.java
@@ -171,10 +171,13 @@ public class SchemaCompatibilityValidator implements FilterPredicate.Visitor<Voi
       return;
     }
 
-    if (descriptor.getMaxRepetitionLevel() > 0) {
-      throw new IllegalArgumentException("FilterPredicates do not currently support repeated columns. "
-          + "Column " + path.toDotString() + " is repeated.");
-    }
+    // comments this check to support row group filtering on columns of repeated type.
+    // Parquet "parquet.filter.record-level.enabled" must be off as record-level filtering
+    // is not supported yet
+    //if (descriptor.getMaxRepetitionLevel() > 0) {
+    //  throw new IllegalArgumentException("FilterPredicates do not currently support repeated columns. "
+    //      + "Column " + path.toDotString() + " is repeated.");
+    //}
 
     ValidTypeMap.assertTypeValid(column, descriptor.getType());
   }

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestSchemaCompatibilityValidator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestSchemaCompatibilityValidator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.filter2.predicate;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;
@@ -130,6 +131,10 @@ public class TestSchemaCompatibilityValidator {
 
   }
 
+  /** Ignore this test as row-group-filtering for columns of repeated type is supported
+   * through a hacky way. see {@link SchemaCompatibilityValidator}
+  */
+  @Ignore
   @Test
   public void testRepeatedNotSupported() {
     try {

--- a/parquet-hive/parquet-hive-storage-handler/pom.xml
+++ b/parquet-hive/parquet-hive-storage-handler/pom.xml
@@ -89,13 +89,11 @@
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hive-binding-factory</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hive-binding-interface</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
   <description>Parquet is a columnar storage format that supports nested data. This provides the java implementation.</description>
 
   <scm>
-    <connection>scm:git:git@github.com:apache/parquet-mr.git</connection>
-    <url>scm:git:git@github.com:apache/parquet-mr.git</url>
-    <developerConnection>scm:git:git@github.com:apache/parquet-mr.git</developerConnection>
+    <connection>scm:git:git@github.com:optimizely/parquet-mr.git</connection>
+    <url>scm:git:git@github.com:optimizely/parquet-mr.git</url>
+    <developerConnection>scm:git:git@github.com:optimizely/parquet-mr.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 
@@ -94,8 +94,8 @@
     <pig.version>0.16.0</pig.version>
     <pig.classifier>h2</pig.classifier>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
-    <thrift.version>0.12.0</thrift.version>
-    <format.thrift.version>0.12.0</format.thrift.version>
+    <thrift.version>0.13.0</thrift.version>
+    <format.thrift.version>0.13.0</format.thrift.version>
     <fastutil.version>8.2.3</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.22</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
   </developers>
 
   <properties>
+    <artifactrepo.url>optimizely-maven</artifactrepo.url>
     <targetJavaVersion>1.8</targetJavaVersion>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
@@ -205,7 +206,25 @@
     </plugins>
   </reporting>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>s3-remote-repository-snapshot</id>
+      <url>s3://optimizely-maven</url>
+    </snapshotRepository>
+    <repository>
+      <id>s3-remote-repository-release</id>
+      <url>s3://optimizely-maven</url>
+    </repository>
+  </distributionManagement>
+
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.kuali.maven.wagons</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.2.1</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -217,6 +236,12 @@
               <phase>none</phase>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
         </plugin>
 
         <plugin>
@@ -366,6 +391,14 @@
           </configuration>
       </plugin>
 
+      <!-- disable gpg sign -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
 
       <plugin>
         <!-- Override source and target from the ASF parent -->
@@ -513,11 +546,10 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 
-  <profiles>
+  <!--profiles>
     <profile>
       <id>update-github-site</id>
       <reporting>
@@ -588,5 +620,5 @@
         <thrift.version>0.9.0</thrift.version>
       </properties>
     </profile>
-  </profiles>
+  </profiles-->
 </project>


### PR DESCRIPTION
Hacky approach to support row group filtering on columns of repeated type (attributes).

Commented out the `maxRepitition` check on SchemaCompatibilityValidator.java to activate row group filtering. The record-level-filtering has to be turned off as the (https://github.com/optimizely/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/filter2/recordlevel/IncrementallyUpdatedFilterPredicate.java#L30) has no support to iterate over list/array type field values and apply the predicate. These changes would enable us to apply only row group filtering on the parquet input split. If the parquet input split block has statistics, dictionary encoded information, the filter predicate will be pushed down.

Support for record level filtering on columns of repeated type will be addressed in future.